### PR TITLE
ptm_sea bug fixes

### DIFF
--- a/phosphodisco/gene_ontology_analysis.py
+++ b/phosphodisco/gene_ontology_analysis.py
@@ -94,15 +94,19 @@ def ptm_per_module(
             ]
         )
         for term, sites in ptm_set_gmt.items():
+            sites = dict(sites)
             n = len(sites)
             overlap = seqs.intersection(set(sites.keys()))
             x = len(overlap)
             overlap = [sites[seq] for seq in overlap]
             pval = scipy.stats.hypergeom.sf(x, M, n, N, loc=1)
             line = pd.Series({
-                'Genes': ','.join(overlap),
+                'Site_set':','.join(sites.values()),
+                'Sites': ','.join(overlap),
                 'Overlap': x,
-                'P-value': pval},
+                'P-value': pval,
+                'Term':term
+                },
                 name=term
             )
             module_results = module_results.append(line)

--- a/phosphodisco/motif_analysis.py
+++ b/phosphodisco/motif_analysis.py
@@ -20,7 +20,7 @@ def find_aa_seqs(
     Returns: AA sequence centered around var_site.
 
     """
-    sites = [int(v.strip()) for v in var_sites.split(var_site_delimiter)]
+    sites = [max(int(v.strip())-1, 0) for v in var_sites.split(var_site_delimiter)]
     seqs = []
     for var_site in sites:
         n = int(var_site)

--- a/phosphodisco/parsers.py
+++ b/phosphodisco/parsers.py
@@ -224,11 +224,11 @@ def read_gmt(gmt_file: str) -> dict:
     result = {}
     with open(gmt_file, 'r') as fh:
         for line in fh.readlines():
-            line = line.strip().split()
+            line = line.strip().split('\t')
             name = line[0]
             site_labels = line[1]
             seqs = line[2:]
-            seq_labels = {seqs[i]: label for i, label in enumerate(site_labels.split('|')[1:])}
+            seq_labels = {seqs[i].split('-')[0]: label for i, label in enumerate(site_labels.split('|')[1:])}
             result.update({name: seq_labels})
 
     return result


### PR DESCRIPTION
These PTM SEA changes fix a variety of bugs in motif_analysis.find_aa_seqs, gene_ontology_analysis.ptm_per_module, and parsers.read_gmt.
I tested all these changes within the notebooks that I came up with them, and imported the modified package, which completed with no errors.

Additional changes to parsers.read_gmt should be implemented eventually, so we can specify what types of PTMs to pull from the PTM_SEA database. Since there are so few non-phospho terms in the database we are using and we are mostly working with phospho, this is currently fine, as it should not impact our p-values too badly. Will certainly add this soon though because it is crucial for making the function work for the other PTM types.