### PR TITLE
added env.yml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,21 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioservices
+  - gseapy
+  - hdbscan
+  - hypercluster
+  - jupyterlab
+  - logomaker
+  - matplotlib-venn
+  - matplotlib<3.2
+  - numpy
+  - openpyxl
+  - oyaml
+  - pandas
+  - pip
+  - pypdf2
+  - scikit-learn
+  - seaborn
+  - snakemake


### PR DESCRIPTION
This environment is set up with all the packages (except ofc phosphodisco) necessary for completing the tutorial.
I will also continue to use this environment for development purposes ofc, and update it as problems arise/requirements change.
Users should use the mamba package manager to create the environment, which takes me about 5 minutes on our compute node.